### PR TITLE
Stop the dependent services without confirmation

### DIFF
--- a/ini-changer.py
+++ b/ini-changer.py
@@ -40,7 +40,7 @@ def disable_rdp_service() -> None:
     """
     Stops Remote Desktop Services so that rdpwrap.ini can be modified.
     """
-    os.system(f'net stop "Remote Desktop Services"')
+    os.system(f'net stop "Remote Desktop Services" /yes')
 
 def enable_rdp_service() -> None:
     """


### PR DESCRIPTION
Add "/yes" to stop all sub-processes without requiring any input.

Example:
"Remote Desktop Services UserMode Port Redirector" will also be stopped